### PR TITLE
Fix magic link connector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ temp/
 .swc/
 *.log
 .DS_Store
+# jns shenanigans
+old_src/

--- a/src/Provider.tsx
+++ b/src/Provider.tsx
@@ -250,8 +250,10 @@ export const ThirdwebProvider = <
     return _supporrtedChains.reduce((prev, curr) => {
       prev[curr.id] =
         curr.id in chainRpc
-          ? chainRpc[curr.id as keyof ChainRpc<TSupportedChain>] ||
-            curr.rpcUrls[0]
+          ? (getProviderForNetwork(
+              chainRpc[curr.id as keyof ChainRpc<TSupportedChain>] ||
+                curr.rpcUrls[0],
+            ) as string)
           : curr.rpcUrls[0];
       return prev;
     }, {} as Record<number, string>);

--- a/src/connectors/magic.ts
+++ b/src/connectors/magic.ts
@@ -16,6 +16,8 @@ export interface MagicConnectorArguments
 
 const __IS_SERVER__ = typeof window === "undefined";
 
+const LOCAL_STORAGE_KEY = "--magic-link:configuration";
+
 export class MagicConnector extends Connector {
   readonly id = "magic";
   readonly name = "Magic";
@@ -30,7 +32,7 @@ export class MagicConnector extends Connector {
       return undefined;
     }
 
-    const config = window.localStorage.getItem("-magic-link:configuration");
+    const config = window.localStorage.getItem(LOCAL_STORAGE_KEY);
     if (config) {
       this.configuration = JSON.parse(config);
     }
@@ -175,12 +177,12 @@ export class MagicConnector extends Connector {
     if (configuration) {
       this.configuration = configuration;
       window.localStorage.setItem(
-        "-magic-link:configuration",
+        LOCAL_STORAGE_KEY,
         JSON.stringify(configuration),
       );
     } else {
       this.configuration = undefined;
-      window.localStorage.removeItem("-magic-link:configuration");
+      window.localStorage.removeItem(LOCAL_STORAGE_KEY);
     }
   }
 }

--- a/src/connectors/magic.ts
+++ b/src/connectors/magic.ts
@@ -51,7 +51,7 @@ export class MagicConnector extends Connector {
   }
 
   async connect(isAutoConnect?: true) {
-    const { apiKey, doNotAutoConnect, rpcUrls, ...options } = this.options;
+    const { apiKey } = this.options;
     const configuration = this.getConfiguration();
 
     try {
@@ -64,7 +64,7 @@ export class MagicConnector extends Connector {
       }
 
       return import("magic-sdk").then(async (m) => {
-        this.magic = new m.Magic(apiKey, options);
+        this.magic = new m.Magic(apiKey);
 
         await this.magic.auth.loginWithMagicLink(configuration);
         const provider = this.getProvider();

--- a/src/connectors/magic.ts
+++ b/src/connectors/magic.ts
@@ -51,7 +51,7 @@ export class MagicConnector extends Connector {
   }
 
   async connect(isAutoConnect?: true) {
-    const { apiKey } = this.options;
+    const { apiKey, doNotAutoConnect, rpcUrls, ...options } = this.options;
     const configuration = this.getConfiguration();
 
     try {
@@ -64,7 +64,7 @@ export class MagicConnector extends Connector {
       }
 
       return import("magic-sdk").then(async (m) => {
-        this.magic = new m.Magic(apiKey);
+        this.magic = new m.Magic(apiKey, options);
 
         await this.magic.auth.loginWithMagicLink(configuration);
         const provider = this.getProvider();


### PR DESCRIPTION
`this.options` looked like this:

![image](https://user-images.githubusercontent.com/35651410/175227150-9b4bba08-ec21-48f0-8481-03c6090e2d96.png)

I *think* maybe what broke it is that when we allowed just passing in the chain name like `'mumbai'` rather than a real RPC URL.

Not sure if this is the best way to fix it, but at least we know what's going wrong now 